### PR TITLE
Specify exclusion of hindcast API modules from standard coverage

### DIFF
--- a/.github/workflows/.coveragerc
+++ b/.github/workflows/.coveragerc
@@ -2,11 +2,12 @@
 omit =
     # omit everything in tests and /hindcast
     ./mhkit/tests/*
-    ./mhkit/wave/io/hindcast/*
+    ./mhkit/wave/io/hindcast.py
+    ./mhkit/wave/io/wind_toolkit.py
 
 [report]
 omit =
     # omit everything in tests and /hindcast
     ./mhkit/tests/*    
-    ./mhkit/wave/io/hindcast/*
-
+    ./mhkit/wave/io/hindcast.py
+    ./mhkit/wave/io/wind_toolkit.py


### PR DESCRIPTION
Should fix coverage issues with https://github.com/MHKiT-Software/MHKiT-Python/pull/187 by specifying exclusion of hindcast and wind toolkit as they are tested in a separate test.  